### PR TITLE
Add reusable InputComponent with styled support

### DIFF
--- a/src/app/component/inputComponent/index.tsx
+++ b/src/app/component/inputComponent/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+import React from "react";
+import { ErrorText, InputWrapper, StyledInput, StyledLabel } from "./style";
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  width?: string;
+}
+
+const InputComponent: React.FC<InputProps> = ({
+  label,
+  error,
+  width,
+  ...props
+}) => {
+  return (
+    <InputWrapper width={width}>
+      {label && <StyledLabel htmlFor={props.id}>{label}</StyledLabel>}
+      <StyledInput {...props} placeholder="Enter Text" />
+      {error && <ErrorText>{error}</ErrorText>}
+    </InputWrapper>
+  );
+};
+
+export default InputComponent;

--- a/src/app/component/inputComponent/style.tsx
+++ b/src/app/component/inputComponent/style.tsx
@@ -1,0 +1,48 @@
+import styled from "styled-components";
+
+interface Props {
+  width?: string | number;
+  hasError?: boolean;
+  isActive?: boolean;
+}
+
+export const InputWrapper = styled.div<Props>`
+  display: flex;
+  flex-direction: column;
+  width: ${({ width }) => width || "100%"};
+  gap: var(--space-16);
+  padding: var(--space-20) var(--space-12);
+  border: 1px solid
+    ${({ hasError, isActive }) =>
+      hasError
+        ? "var(--red)"
+        : isActive
+        ? "var(--grey-darkest)"
+        : "var(--grey-light)"};
+`;
+
+export const StyledLabel = styled.label`
+  font-size: 14px;
+  color: var(--grey-darkest);
+  font-weight: 500;
+`;
+
+export const StyledInput = styled.input<{ hasError?: boolean }>`
+  padding: 12px 16px;
+  border-radius: 8px;
+
+  background: var(--white);
+  font-size: 16px;
+  color: var(--grey-darkest);
+  outline: none;
+  transition: border 0.2s;
+  &:focus {
+    border-color: var(--grey-dark);
+  }
+`;
+
+export const ErrorText = styled.span`
+  color: var(--red);
+  font-size: 12px;
+  margin-top: 2px;
+`;


### PR DESCRIPTION
Introduces a new InputComponent with label, error, and width props, along with associated styled-components for consistent UI and error handling.