### PR TITLE
Refactor color variable naming and usage

### DIFF
--- a/src/app/component/button/style.tsx
+++ b/src/app/component/button/style.tsx
@@ -24,17 +24,17 @@ export const Buttons = styled.button<WrappButton>`
   ${({ variant }) =>
     variant === BUTTON_TYPE.PRIMARY &&
     css`
-      background-color: var(--grey-darkest);
+      background-color: var(--grey-900);
       color: var(--white);
       &:hover {
-        background-color: var(--grey-dark);
+        background-color: var(--grey-500);
       }
     `}
   ${({ variant }) =>
     variant === BUTTON_TYPE.SECONDARY &&
     css`
-      background-color: var(--beige-light);
-      color: var(--grey-darkest);
+      background-color: var(--beige-100);
+      color: var(--grey-900);
       &:hover {
         background-color: var(--white);
         box-shadow: var(--border);
@@ -45,16 +45,16 @@ export const Buttons = styled.button<WrappButton>`
     css`
       background-color: unset;
       padding: var(--space-0);
-      color: var(--grey-dark);
+      color: var(--grey-500);
       gap: var(--space-12);
       svg path {
-        fill: var(--grey-dark);
+        fill: var(--grey-500);
       }
       &:hover {
-        color: var(--grey-darkest);
+        color: var(--grey-900);
         background-color: unset;
         svg path {
-          fill: var(--grey-darkest);
+          fill: var(--grey-900);
         }
       }
     `}

--- a/src/app/component/inputComponent/style.tsx
+++ b/src/app/component/inputComponent/style.tsx
@@ -17,13 +17,13 @@ export const InputWrapper = styled.div<Props>`
       hasError
         ? "var(--red)"
         : isActive
-        ? "var(--grey-darkest)"
-        : "var(--grey-light)"};
+        ? "var(--grey-900)"
+        : "var(--grey-300)"};
 `;
 
 export const StyledLabel = styled.label`
   font-size: 14px;
-  color: var(--grey-darkest);
+  color: var(--grey-900);
   font-weight: 500;
 `;
 
@@ -33,11 +33,11 @@ export const StyledInput = styled.input<{ hasError?: boolean }>`
 
   background: var(--white);
   font-size: 16px;
-  color: var(--grey-darkest);
+  color: var(--grey-900);
   outline: none;
   transition: border 0.2s;
   &:focus {
-    border-color: var(--grey-dark);
+    border-color: var(--grey-500);
   }
 `;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,13 @@
 :root {
   /* color variables */
   /* beige */
-  --beige-light: #f8f4f0;
-  --beige-dark: #98908b;
+  --beige-100: #f8f4f0;
+  --beige-500: #98908b;
   /* grey */
-  --grey-lightest: #f2f2f2;
-  --grey-light: #b3b3b3;
-  --grey-dark: #696868;
-  --grey-darkest: #201f22;
+  --grey-100: #f2f2f2;
+  --grey-300: #b3b3b3;
+  --grey-500: #696868;
+  --grey-900: #201f22;
   --navy-grey: #97a0ac;
   /* secondary */
   --green: #277c78;


### PR DESCRIPTION
Updated CSS variable names for beige and grey colors to use numeric scales (e.g., --grey-900, --beige-100) for consistency. Refactored all references in button and input component styles to use the new variable names, improving maintainability and clarity.